### PR TITLE
feat(backend): upgraded pyjwt dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ title = __import__("dat_utils").__title__
 version = __import__("dat_utils").__version__
 
 
-install_requires = ["pyjwt~=1.7.1"]
+install_requires = ["pyjwt~=2.1.0"]
 
 
 setup(


### PR DESCRIPTION
Upgraded **pyjwt** dependency from 1.7.1 to 2.1.0.

**djangorestframework-simplejw**t (which is a dependency of **data-sources-directory**) requires `pyjwt >=2,<3`.